### PR TITLE
Added a function to check if origin is present in SWH archive or not.

### DIFF
--- a/src/heritedcode_api_functions.py
+++ b/src/heritedcode_api_functions.py
@@ -108,7 +108,7 @@ def get_content_information(checksum_type, checksum):
 
 def is_origin_present(origin_url):
     """
-    Return a boolean flag which states is given origin present in SWH archive or not.
+    Return a boolean flag if given origin is present in SWH archive.
     """
     assert (
         type(origin_url) == str
@@ -116,9 +116,10 @@ def is_origin_present(origin_url):
 
     api = f"{BASE_SWH_API_URL}origin/search/{origin_url}?limit=1"
     response = requests.get(api)
+    status_code = response.status_code
+    assert status_code == 200, "An error occurred while making a request"
     response = response.json()
-    length_of_array = len(response)
 
-    if length_of_array > 0 and response[0]["url"] == origin_url:
+    if response and response[0].get("url") == origin_url:
         return True
     return False

--- a/src/heritedcode_api_functions.py
+++ b/src/heritedcode_api_functions.py
@@ -104,3 +104,21 @@ def get_content_information(checksum_type, checksum):
         status=response["status"],
     )
     return response_object
+
+
+def is_origin_present(origin_url):
+    """
+    Return a boolean flag which states is given origin present in SWH archive or not.
+    """
+    assert (
+        type(origin_url) == str
+    ), f"origin_url: {origin_url!r} must be string, not {type(origin_url)!r}."
+
+    api = f"{BASE_SWH_API_URL}origin/search/{origin_url}?limit=1"
+    response = requests.get(api)
+    response = response.json()
+    length_of_array = len(response)
+
+    if length_of_array > 0 and response[0]["url"] == origin_url:
+        return True
+    return False

--- a/tests/test_heritedcode_api_functions.py
+++ b/tests/test_heritedcode_api_functions.py
@@ -51,3 +51,21 @@ def test_get_content_information(requests_mock):
         heritedcode_api_functions.get_content_information(checksum_type, checksum)
         == expected_output
     )
+
+
+def test_is_origin_present(requests_mock):
+    # input data
+    origin_url = "https://github.com/nexB/scancode-toolkit"
+
+    json_output = [
+        {
+            "origin_visits_url": "https://archive.softwareheritage.org/api/1/origin/https://github.com/nexB/scancode-toolkit/visits/",
+            "url": "https://github.com/nexB/scancode-toolkit",
+        }
+    ]
+    expected_output = True
+
+    api = f"{BASE_SWH_API_URL}origin/search/{origin_url}?limit=1"
+    requests_mock.get(api, json=json_output)
+
+    assert heritedcode_api_functions.is_origin_present(origin_url) == expected_output


### PR DESCRIPTION
Added a function to check if origin is present in SWH archive or not.Made an api call to SWH api [https://archive.softwareheritage.org/api/1/origin/search](url) which searches for given origin url and returns an array of matched origins ranked according to the perfect match.Then if our origin url is present in first object of that array that means origin is present in SWH archive else not.
Signed-off-by: Sanket Varpe <varpesanket2000@gmail.com>